### PR TITLE
Fix crash opening Spore Manager

### DIFF
--- a/scripts/utils/node_utils.py
+++ b/scripts/utils/node_utils.py
@@ -4,6 +4,7 @@ module provides quick acces to frequently used node utilities
 
 import math
 
+import maya.cmds as cmds
 import maya.OpenMaya as om
 
 


### PR DESCRIPTION
If `cmds` is not imported, spore will crash in `scripts/utils/node_utils.py`, line 37 when opening Spore Manager: 

```python
    if not cmds.objExists(name):
# NameError: global name 'cmds' is not defined # 
```